### PR TITLE
🔥 [HOTFIX] Fix Dockerfile MOTD syntax error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV VERSION=${VERSION:-LATEST} \
     VIEW_DISTANCE=${VIEW_DISTANCE:-10} \
     SIMULATION_DISTANCE=${SIMULATION_DISTANCE:-10} \
     LEVEL_NAME=${LEVEL_NAME:-world} \
-    MOTD=${MOTD:-A Minecraft Server} \
+    MOTD="${MOTD:-A Minecraft Server}" \
     SPAWN_PROTECTION=${SPAWN_PROTECTION:-16}
 
 # Auto-pause configuration for resource optimization


### PR DESCRIPTION
Closes #40

## Bug Critico en Dockerfile

Error de sintaxis impide construir la imagen Docker.

### Problema
`
failed to solve: Syntax error - cant find = in Minecraft
`

Linea 23: MOTD sin comillas causa error de parsing.

### Solucion
Agregar comillas alrededor del valor por defecto del MOTD.

### Testing
`
docker compose build  # Build exitoso
docker compose up -d  # Container corriendo
`

### Impacto
- CRITICO: Bloquea deployment
- No se puede construir imagen
- Afecta nuevos usuarios

### Approval Required
HOTFIX CRITICO a main.
Requiere aprobacion manual del owner (@gastonfr24).
